### PR TITLE
build(docker): fix pnpm version and update node base image to v22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-# 1. Base - Instalando o que é comum para todos
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 RUN pnpm add -g turbo
 WORKDIR /app
 


### PR DESCRIPTION

### 📝 Title

`build(docker): fix container build pipeline by pinning pnpm version and updating node image`

---

### 📋 Summary

This PR fixes the Docker build pipeline failure during deployment by updating the Node.js base image and pinning the `pnpm` version using Corepack to prevent breaking changes from upstream tool releases.

---

### 🔄 Changes Made

* **Node.js Base Image:** Updated the Dockerfile base image to `node:22-alpine` to ensure runtime parity between local development and container environments.
* **PNPM Version Pinning:** Fixed `pnpm` to version `9.15.4` using `corepack prepare pnpm@9.15.4 --activate` to prevent Corepack from fetching incompatible versions (e.g., `pnpm v11+` which requires native SQLite modules).

---

### ✅ Verification

* [x] Verified local container build passes without errors.
* [x] Confirmed compatibility with existing dependencies and Turbo orchestrator.