### PR TITLE
fix(web): wrap reset-password searchParams in Suspense boundary

### DIFF
--- a/apps/web/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/(auth)/reset-password/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 
-export default function ResetPasswordPage() {
+function ResetPasswordForm() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -133,5 +133,17 @@ export default function ResetPasswordPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center text-white">
+        Loading...
+      </div>
+    }>
+      <ResetPasswordForm />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## 📌 PR Description

### 📋 Summary
Fixes Next.js static prerendering error on `/(auth)/reset-password` during production build by wrapping the component utilizing `useSearchParams()` inside a React `<Suspense>` boundary.

---

### 🔄 Changes Made
- Refactored `apps/web/src/app/(auth)/reset-password/page.tsx` into a client-side form subcomponent (`ResetPasswordForm`).
- Exported the main page component wrapped with `<Suspense>` to ensure CSR bailout compliance during static page generation in `next build`.

---

### ✅ Verification
- [x] Verified `pnpm --filter=@saas/web build` succeeds locally without prerender exceptions.