### PR TITLE
fix(docker): generate prisma client before turbo build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY turbo.json turbo.json
+
+RUN pnpm --filter=@saas/api-tasks exec prisma generate --schema=apps/api-tasks/prisma/schema.prisma
+
 RUN pnpm turbo build
 
 FROM base AS runner


### PR DESCRIPTION
## 📌 PR Description

### 📋 Summary
Fixes the runtime exception `@prisma/client did not initialize yet` occurring during container startup in Render deployment by adding explicit Prisma Client generation during the Docker build stage.

---

### 🔄 Changes Made
- Added `RUN pnpm --filter=@saas/api-tasks exec prisma generate --schema=apps/api-tasks/prisma/schema.prisma` in `Dockerfile` right before `pnpm turbo build`.
- Ensures the Prisma Client artifacts are generated and copied over to the final `runner` image context.

---

### ✅ Verification
- [x] Verified build step resolves schema location without triggering `@prisma/client` initialization warnings.
- [x] Prepares NestJS runtime to successfully inject `PrismaService` upon server start.