### PR TITLE
fix(docker): fix relative prisma schema path in build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pnpm install --frozen-lockfile
 COPY --from=pruner /app/out/full/ .
 COPY turbo.json turbo.json
 
-RUN pnpm --filter=@saas/api-tasks exec prisma generate --schema=apps/api-tasks/prisma/schema.prisma
+RUN pnpm --filter=@saas/api-tasks exec prisma generate --schema=./prisma/schema.prisma
 
 RUN pnpm turbo build
 


### PR DESCRIPTION
## 📌 PR Description

### 📋 Summary
Fixes the Docker build failure caused by an invalid relative file path when executing `prisma generate` via `pnpm --filter`.

---

### 🔄 Changes Made
- Updated the `--schema` flag path in `Dockerfile` from `apps/api-tasks/prisma/schema.prisma` to `./prisma/schema.prisma`.
- **Reason:** `pnpm --filter=@saas/api-tasks exec` changes the working context directly to `/app/apps/api-tasks`, so the path needs to be relative to that directory.

---

### ✅ Verification
- [x] Corrected working directory resolution for the Prisma Client generation step.
- [x] Ensures `pnpm turbo build` completes successfully in the Docker container layer.