### PR TITLE
fix(api-tasks): fix port binding logic to read process.env.PORT inste…

### DIFF
--- a/apps/api-tasks/src/main.ts
+++ b/apps/api-tasks/src/main.ts
@@ -5,10 +5,13 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.enableCors();
-  const port = process.env.APP_URL ? parseInt(process.env.APP_URL, 10) : 3002;
+
+  const rawPort = process.env.PORT;
+  const parsedPort = rawPort ? parseInt(rawPort, 10) : NaN;
+  const port = !Number.isNaN(parsedPort) && parsedPort > 0 ? parsedPort : 3002;
 
   await app.listen(port, '0.0.0.0');
 
-  console.log(`✅ Microserviço API-TASKS rodando em: http://localhost:3002`);
+  console.log(`✅ Microserviço API-TASKS rodando em: ${port}`);
 }
 bootstrap();


### PR DESCRIPTION
## 📌 Overview

Fixed a bug in `main.ts` where `process.env.APP_URL` was mistakenly passed to `parseInt()`, causing the application port to resolve to `NaN` and failing with `ERR_SOCKET_BAD_PORT`.

### 🛠️ Key Changes
- Replaced `process.env.APP_URL` with `process.env.PORT` in the port parsing logic.
- Added validation for `parsedPort` with a fallback to `3002` for local development.

---

## 🧪 Verification
Deployed to Render staging and confirmed the service successfully binds to the platform-assigned port without crashing during startup.