### PR TITLE
fix(ai-service): reduce uvicorn workers and handle dynamic PORT binding

### DIFF
--- a/Dockerfile.ai
+++ b/Dockerfile.ai
@@ -18,4 +18,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1


### PR DESCRIPTION
## 🚑 Hotfix: Render Deployment Fixes

### 🐛 Problem
The deployment on Render failed due to an Out of Memory (OOM) error on the 512MB RAM tier caused by running 4 Uvicorn workers, along with port binding issues.

### 🛠️ Solution
- Reduced Uvicorn workers from `4` to `1` in `Dockerfile.ai` to fit within memory limits.
- Updated execution command to use dynamic `${PORT:-8000}` binding for Render compatibility.